### PR TITLE
Replaced 1/7 value with arbritrary tag

### DIFF
--- a/react/src/Calendar.tsx
+++ b/react/src/Calendar.tsx
@@ -177,7 +177,7 @@ const Calendar: FunctionComponent = () => {
                             style={{ marginBottom: "-30px" }}
                         >
                             {days.map((day) => (
-                                <div key={day} className="px-2 py-2 w-1/7">
+                                <div key={day} className="px-2 py-2 w-[14.28%]">
                                     <div className="text-gray-600 text-sm uppercase tracking-wide font-bold text-center">
                                         {day}
                                     </div>
@@ -188,13 +188,13 @@ const Calendar: FunctionComponent = () => {
                             {emptyDays.map((emptyDay) => (
                                 <div
                                     key={emptyDay}
-                                    className="text-center border-r border-b px-4 pt-2 h-32 w-1/7"
+                                    className="text-center border-r border-b px-4 pt-2 h-32 w-[14.28%]"
                                 />
                             ))}
                             {numOfDays.map((date, index) => (
                                 <div
                                     key={index}
-                                    className="px-4 pt-2 border-r border-b relative h-32 w-1/7"
+                                    className="px-4 pt-2 border-r border-b relative h-32 w-[14.28%]"
                                 >
                                     <div
                                         className={classNames(

--- a/vue/src/components/Calendar.vue
+++ b/vue/src/components/Calendar.vue
@@ -25,7 +25,7 @@
       <div class="-mx-1 -mb-1">
         <div class="flex flex-wrap -mb-8" style="margin-bottom: -30px;">
           <template v-for="day in days">
-            <div class="px-2 py-2 w-1/7">
+            <div class="px-2 py-2 w-[14.28%]">
               <div v-text="day" class="text-gray-600 text-sm uppercase tracking-wide font-bold text-left mb-1"></div>
             </div>
           </template>
@@ -33,10 +33,10 @@
 
         <div class="flex flex-wrap border-t border-l">
           <template v-for="emptyDay in emptyDays">
-            <div class="text-left border-r border-b px-4 pt-2 h-32 w-1/7"></div>
+            <div class="text-left border-r border-b px-4 pt-2 h-32 w-[14.28%]"></div>
           </template>
           <template v-for="(date, dateIndex) in no_of_days">
-            <div class="px-4 pt-2 border-r border-b relative h-32 w-1/7">
+            <div class="px-4 pt-2 border-r border-b relative h-32 w-[14.28%]">
               <div @click="showDayModal(date)" v-text="date"
                    class="inline-flex w-6 h-6 items-center justify-center cursor-pointer text-center leading-none rounded-full transition ease-in-out duration-100"
                    :class="{'bg-blue-500 text-white': isToday(date) === true, 'text-gray-700 hover:bg-blue-200': isToday(date) === false }"></div>


### PR DESCRIPTION
Using the `w-1/7` className does not work, Tailwind only supports a set of pre-determined fractions of which, sadly, 7 is not one of. Substituted the fraction with Tailwinds arbitrary brackets and put in the corresponding percentage `w-[14.28%]` and it works great 